### PR TITLE
chore: sync framework @ 1.3.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   /*
   // Building the image from the Dockerfile
   "build": {
-    "dockerfile": "Dockerfile"
+    "image": "shinojosa/dt-enablement:v1.2"
     },
     */
   // When running locally we pass the 'secrets' as env variables via runArgs "--env-file",".devcontainer/.env"

--- a/.devcontainer/test/integration.sh
+++ b/.devcontainer/test/integration.sh
@@ -12,4 +12,4 @@ assertRunningPod astroshop cart
 
 assertRunningPod astroshop checkout
 
-assertRunningApp 30100
+assertRunningApp astroshop

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.2.7}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.0}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"


### PR DESCRIPTION
## Sync update

- Bumps `FRAMEWORK_VERSION` from `1.2.7` to `1.3.0`.
- Updates templates (`source_framework.sh`, `Makefile`).
- Removes framework-owned files (Category A) — now pulled from cache.

Auto-generated by `sync push-update`.