### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/04_bizevents_oneagent.md
+++ b/docs/04_bizevents_oneagent.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-04-bizevents-oneagent.js"
 
 # Business Events Capture - OneAgent
 

--- a/docs/05_bizevents_logs.md
+++ b/docs/05_bizevents_logs.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-05-bizevents-logs.js"
 
 # Business Events Capture - Logs
 

--- a/docs/06_bizevents_api.md
+++ b/docs/06_bizevents_api.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-06-bizevents-api.js"
 
 # Business Events Capture - API
 

--- a/docs/07_bizevents_metric.md
+++ b/docs/07_bizevents_metric.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-07-bizevents-metric.js"
 
 # Business Events - Metric
 

--- a/docs/08_bizevents_alerts.md
+++ b/docs/08_bizevents_alerts.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-08-bizevents-alert.js"
 
 # Business Events - Alert
 

--- a/docs/09_bizevents_business_flow.md
+++ b/docs/09_bizevents_business_flow.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevents-09-business-flow.js"
 
 # Business Events - Business Flow
   

--- a/docs/10_bizevents_dashboard.md
+++ b/docs/10_bizevents_dashboard.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-10-bievents-dashboard.js"
 
 # Dashboards
 

--- a/docs/11_wrapup.md
+++ b/docs/11_wrapup.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-wrapup.js"
 # Wrap Up
 
 ## Key Takeaways

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-cleanup.js"
 # Clean Up
 
 --8<-- "snippets/feedback.md"

--- a/docs/codespaces.md
+++ b/docs/codespaces.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-codespaces.js"
 # Codespaces
 
 --8<-- "snippets/dt-enablement.md"

--- a/docs/content-template.md
+++ b/docs/content-template.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/file.js"
 
 ## Topic
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-getting-started.js"
 
 # Getting Started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/bizevent-index.js"
 # Enablement Business Observability
 
 --8<-- "snippets/disclaimer.md"

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/snippets/send-bizevent/bizevent-04-bizevents-oneagent.js
+++ b/docs/snippets/send-bizevent/bizevent-04-bizevents-oneagent.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. Business Events Capture - OneAgent"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-05-bizevents-logs.js
+++ b/docs/snippets/send-bizevent/bizevent-05-bizevents-logs.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. Business Events Capture - Logs"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-06-bizevents-api.js
+++ b/docs/snippets/send-bizevent/bizevent-06-bizevents-api.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. Business Events Capture - API"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-07-bizevents-metric.js
+++ b/docs/snippets/send-bizevent/bizevent-07-bizevents-metric.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. Business Events Capture - Metric"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-08-bizevents-alert.js
+++ b/docs/snippets/send-bizevent/bizevent-08-bizevents-alert.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "08. Business Events Capture - Alert"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-08-bizevents-alerts.js
+++ b/docs/snippets/send-bizevent/bizevent-08-bizevents-alerts.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "8. Business Events Capture - Alerts"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-09-bizevents-business-flow.js
+++ b/docs/snippets/send-bizevent/bizevent-09-bizevents-business-flow.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "09. Business Events - Business Flow"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-10-bizevents-dashboard.js
+++ b/docs/snippets/send-bizevent/bizevent-10-bizevents-dashboard.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "10. Business Events - Business Dashboard "})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-11-wrapup.js
+++ b/docs/snippets/send-bizevent/bizevent-11-wrapup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "11. Wrap Up "})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-cleanup.js
+++ b/docs/snippets/send-bizevent/bizevent-cleanup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "12. Cleanup"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-codespaces.js
+++ b/docs/snippets/send-bizevent/bizevent-codespaces.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Codespaces"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-getting-started.js
+++ b/docs/snippets/send-bizevent/bizevent-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-index.js
+++ b/docs/snippets/send-bizevent/bizevent-index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"})
-});
-</script>

--- a/docs/snippets/send-bizevent/bizevent-wrapup.js
+++ b/docs/snippets/send-bizevent/bizevent-wrapup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "11. Wrap Up"})
-});
-</script>


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)