### PR TITLE
docs: add Enablement App migration status banner

### DIFF
--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.9.8}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.10.0}"
 
 # Derive REPO_PATH from this script's own location (repo/.devcontainer/util/...),
 # NOT from $(pwd): shells opened outside the repo dir (docker exec lands in "/")

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,11 @@
 # Enablement Business Observability
 
+!!! warning "Not yet migrated to the Dynatrace Enablement App"
+    This training has not been migrated to a fully immersive, interactive and self-service training.
+    Questions or feedback? Reach out to the Center of Excellence Enablement Team via
+    [GitHub Issues](https://github.com/dynatrace-wwse/codespaces-framework/issues)
+    or the [feedback form](https://forms.office.com/r/QaCx6VAJe8).
+
 --8<-- "snippets/disclaimer.md"
 --8<-- "snippets/view-code.md"
 


### PR DESCRIPTION
## What

Adds an Enablement App migration status banner to this repo's first documentation page.

Status for this repo: **not-migrated**.

## Why

The Dynatrace Hub lists 26 repos, but nothing on the Hub, in the GitHub Pages docs
or in the Enablement App tells a learner which trainings are already immersive,
interactive and self-service in the app, which are mid-conversion, and which are not
migrated yet. This banner makes that visible on the page itself.

## Why inline text and not a `docs/snippets/` include

The app's importer strips `--8<-- "snippets/..."` lines
(`stripSnippetIncludes`, `api/import-lab.helpers.ts`). A snippet-based banner would
look right on GitHub Pages and be silently dropped in the Enablement App — the surface
it exists to serve. So the banner is literal Markdown in the page.

## Verification

Rendered through both real parsers, not a reimplementation:

| Surface | Parser | Result |
|---|---|---|
| GitHub Pages | Python-Markdown `admonition` | `<div class="admonition ...">` with working contact links |
| Enablement App | `stripSnippetIncludes()` + `preprocessMarkdown()` | `<div data-admonition="...">`, banner is the first block |

## Please leave this PR open

This is one of 23 repos in a fleet-wide wave. Framework **1.10.0** will add a
minimalistic Orbital-specific container greeting, and the `FRAMEWORK_VERSION` bump
will be pushed onto this same branch so the banner and the greeting ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
